### PR TITLE
chore(deps): grab current plumed-metatomic

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   depth: 1
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win or py2k]
   string: py{{ CONDA_PY }}_h{{ PKG_HASH }}_git.{{ git_rev[:7] }}_{{ PKG_BUILDNUM }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.


Should fix the issue with diamond deps when trying to resolve `conda install -c metatensor lammps-metatomic py-plumed-metatomic plumed-metatomic`


```bash

Could not solve for environment specs
The following packages are incompatible
├─ lammps-metatomic =* * is not installable because there are no viable options
│  ├─ lammps-metatomic 2025.09.10.mta0 would require
│  │  ├─ libmetatensor-torch >=0.8.1,<0.9.0 *, which can be installed;
│  │  └─ plumed-metatomic =* nompi* but there are no viable options
│  │     ├─ plumed-metatomic 2.10.0.dev0 would require
│  │     │  └─ libmetatensor-torch >=0.7.6,<0.8.0 *, which conflicts with any installable versions previously reported;
│  │     └─ plumed-metatomic [2.10.0|2.10.0.dev1] conflicts with any installable versions previously reported;
│  ├─ lammps-metatomic 2025.09.10.mta0 would require
│  │  ├─ libmetatensor-torch >=0.8.1,<0.9.0 *, which can be installed;
│  │  └─ plumed-metatomic =* mpi_mpich* but there are no viable options
│  │     ├─ plumed-metatomic 2.10.0.dev0, which cannot be installed (as previously explained);
│  │     └─ plumed-metatomic [2.10.0|2.10.0.dev1] conflicts with any installable versions previously reported;
│  ├─ lammps-metatomic 2025.09.10.mta0 would require
│  │  ├─ libmetatensor-torch >=0.8.1,<0.9.0 *, which can be installed;
│  │  └─ plumed-metatomic =* mpi_openmpi* but there are no viable options
│  │     ├─ plumed-metatomic 2.10.0.dev0, which cannot be installed (as previously explained);
│  │     └─ plumed-metatomic [2.10.0|2.10.0.dev1] conflicts with any installable versions previously reported;
│  ├─ lammps-metatomic 2025.09.10.mta1 would require
│  │  ├─ libmetatensor-torch >=0.8.2,<0.9.0 *, which can be installed;
│  │  └─ plumed-metatomic =* mpi_mpich* but there are no viable options
│  │     ├─ plumed-metatomic 2.10.0.dev0, which cannot be installed (as previously explained);
│  │     └─ plumed-metatomic [2.10.0|2.10.0.dev1] conflicts with any installable versions previously reported;
│  ├─ lammps-metatomic 2025.09.10.mta1 would require
│  │  ├─ libmetatensor-torch >=0.8.2,<0.9.0 *, which can be installed;
│  │  └─ plumed-metatomic =* mpi_openmpi* but there are no viable options
│  │     ├─ plumed-metatomic 2.10.0.dev0, which cannot be installed (as previously explained);
│  │     └─ plumed-metatomic [2.10.0|2.10.0.dev1] conflicts with any installable versions previously reported;
│  └─ lammps-metatomic 2025.09.10.mta1 would require
│     ├─ libmetatensor-torch >=0.8.2,<0.9.0 *, which can be installed;
│     └─ plumed-metatomic =* nompi* but there are no viable options
│        ├─ plumed-metatomic 2.10.0.dev0, which cannot be installed (as previously explained);
│        └─ plumed-metatomic [2.10.0|2.10.0.dev1] conflicts with any installable versions previously reported;
├─ pin on python =3.12 * is installable and it requires
│  └─ python =3.12 *, which can be installed;
└─ py-plumed-metatomic =* * is not installable because there are no viable options
   ├─ py-plumed-metatomic 2.10.0.dev0 would require
   │  └─ plumed-metatomic =2.10.0.dev0 *, which cannot be installed (as previously explained);
   ├─ py-plumed-metatomic 2.10.0.dev0 would require
   │  └─ python >=3.10,<3.11.0a0 *, which conflicts with any installable versions previously reported;
   ├─ py-plumed-metatomic 2.10.0.dev0 would require
   │  └─ python >=3.13,<3.14.0a0 *, which conflicts with any installable versions previously reported;
   ├─ py-plumed-metatomic 2.10.0.dev0 would require
   │  └─ python >=3.9,<3.10.0a0 *, which conflicts with any installable versions previously reported;
   └─ py-plumed-metatomic 2.10.0.dev0 would require
      └─ python >=3.11,<3.12.0a0 *, which conflicts with any installable versions previously reported.

Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.12
```